### PR TITLE
Replace `get-doc-ref` with `get-meta`, move `meta-ref`

### DIFF
--- a/punct-doc/punct.scrbl
+++ b/punct-doc/punct.scrbl
@@ -625,13 +625,25 @@ get a friendly error message. If any other kind of problem arises, you will get 
 
 }
 
-@defproc[(get-doc-ref [src path-string?] [key symbol?]) any/c]{
+@defproc[(get-meta [doc document?]
+                   [key symbol?]
+                   [default failure-result/c (lambda () (raise (make-exn:fail ....)))])
+         any/c]{
 
-Returns the value of @racket[_key] in the @racketidfont{metas} hash table provided by @racket[_src],
-or @racket[#f] if the key does not exist in that hash table. If @racket[_src] does not exist, you
-will get a friendly error message. If any other kind of problem arises, you will get an ugly error.
+Returns the value of @racket[_key] in the @racket[document-metas] of @racket[_doc].
+The value of @racket[_default] is used if the key does not exist: if it is a value, that value will be
+returned instead; if it is a thunk, the thunk will be called.
+
+@history[#:changed "1.1" @elem{Removed @racketidfont{get-doc-ref} and replaced with @racket[get-meta]}]
 
 }
+
+@defproc[(meta-ref [doc document?] [key symbol?]) any/c]{
+
+Equivalent to @racket[(get-meta doc key #f)]. Provided for compatibility.
+                                                         
+}
+         
 
 @subsection{Parse}
 

--- a/punct-lib/doc.rkt
+++ b/punct-lib/doc.rkt
@@ -4,7 +4,7 @@
 ; This file is licensed under the Blue Oak Model License 1.0.0.
 (require "private/quasi-txpr.rkt")
 
-(provide (struct-out document) meta-ref block-element? inline-element?)
+(provide (struct-out document) block-element? inline-element?)
 
 #| Punct’s document structure is very similar to Commonmark’s,
    except that it is prefab and uses simple lists instead of
@@ -15,9 +15,6 @@
 |#
 
 (struct document (metas body footnotes) #:prefab)
-
-(define (meta-ref doc key)
-  (hash-ref (document-metas doc) key #f))
 
 ;; These functions are not actually used in punct-lib. They exist only to have some clear
 ;; predicates for use in the documentation.

--- a/punct-lib/fetch.rkt
+++ b/punct-lib/fetch.rkt
@@ -1,14 +1,20 @@
 #lang racket/base
 
-(require "doc.rkt")
+(require "doc.rkt"
+         racket/match)
 
 (provide get-doc
-         get-doc-ref)
+         get-meta
+         meta-ref)
 
 (define (get-doc src [caller 'get-doc])
   (unless (file-exists? src)
     (raise-argument-error 'get-doc "path to existing file" src))
   (dynamic-require src 'doc))
 
-(define (get-doc-ref src key)
-  (hash-ref (document-metas (get-doc src 'get-doc-ref)) key #f))
+(define (get-meta doc k [default (λ ()
+                                   (define path (hash-ref (document-metas doc) 'here-path))
+                                   (error 'get-meta "key ~s not found\n  document: ~a" k path))])
+  (hash-ref (document-metas doc) k default))
+
+(define (meta-ref doc k) (get-meta doc k #f))

--- a/punct-lib/info.rkt
+++ b/punct-lib/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 
 (define collection "punct")
-(define version "1.0")
+(define version "1.1")
 (define pkg-desc "implementation part of \"punct\"")
 (define license 'BlueOak-1.0.0)
 


### PR DESCRIPTION
This PR eliminates `get-doc-ref` (which takes a path and a key) and adds a `get-meta` (which takes a `document` and a key).

Getting a meta by way of the path of the source file (vs. from an already-loaded `document`) proves to be less useful than I imagined it would be.

This PR also moves the (previously undocumented) `meta-ref` from `punct/doc` to `punct/fetch` and adds documentation. I use this a lot in templates when fetching metas that I want to treat as optional. I elected to keep it for that use and in case anyone depends on it. It might need a new name to better distinguish it from `get-meta`.