### PR TITLE
Allow quoted datums as meta values

### DIFF
--- a/punct-doc/punct.scrbl
+++ b/punct-doc/punct.scrbl
@@ -203,7 +203,8 @@ This is a syntactic convenience that comes with a few rules and limitations:
 @racketmodfont{#lang} line.}
 
 @item{Each value will always be parsed as a flat string --- or, if prefixed with a single quote
-@litchar{'}, as a simple datum (using @racket[read]).}
+@litchar{'}, as a simple datum (using @racket[read]). If more than one datum appears after the
+@litchar{'}, the first will be used and the rest discarded.}
 
 ]
 

--- a/punct-doc/punct.scrbl
+++ b/punct-doc/punct.scrbl
@@ -181,14 +181,15 @@ directly on the @hash-lang[] line.}]
 
 @subsection[#:tag "metas block"]{Metadata block}
 
-Sources can optionally add metadata using key: value lines delimited by lines consisting only of
-consecutive hyphens:
+Sources can optionally add metadata using @racketvalfont{key: value} lines, delimited by lines
+consisting only of consecutive hyphens:
 
 @codeblock{
  #lang punct
  ---
  title: Prepare to be amazed
  date: 2020-05-07
+ draft?: '#t
  ---
 
  Regular content goes here
@@ -201,14 +202,20 @@ This is a syntactic convenience that comes with a few rules and limitations:
 @item{The metadata block must be the first non-whitespace thing that follows the
 @racketmodfont{#lang} line.}
 
-@item{The values will always be parsed as flat strings.}
+@item{Each value will always be parsed as a flat string --- or, if prefixed with a single quote
+@litchar{'}, as a simple datum (using @racket[read]).}
 
-@item{The reader will not evaluate any escaped code inside the metadata block; all characters in the
-keys and values will be used verbatim.}]
+]
 
-If you want to use non-string values, or the results of expressions, in your metadata, you can use
-the @racket[set-meta] function anywhere in the document or in code contained in other modules.
-Within the document body you can also use the @racket[?] macro as shorthand for @racket[set-meta].
+Prefixing meta values with @litchar{'} allows you to store booleans and numbers, as well as complex
+values like lists, vectors, hash tables, or anything else that @racket[read] would count as a single
+datum --- but note that code inside the value will not be evaluated.
+
+If you want to use the results of expressions in your metadata, you can use the @racket[set-meta]
+function anywhere in the document or in code contained in other modules. Within the document body
+you can also use the @racket[?] macro as shorthand for @racket[set-meta].
+
+@history[#:changed "1.2" @elem{Added ability to use datums quoted with @litchar{'} in metadata.}]
 
 @subsection{Markdown and Racket}
 

--- a/punct-doc/punct.scrbl
+++ b/punct-doc/punct.scrbl
@@ -209,7 +209,7 @@ This is a syntactic convenience that comes with a few rules and limitations:
 
 Prefixing meta values with @litchar{'} allows you to store booleans and numbers, as well as complex
 values like lists, vectors, hash tables, or anything else that @racket[read] would count as a single
-datum --- but note that code inside the value will not be evaluated.
+datum (and which fits in one line) --- but note that code inside the value will not be evaluated.
 
 If you want to use the results of expressions in your metadata, you can use the @racket[set-meta]
 function anywhere in the document or in code contained in other modules. Within the document body

--- a/punct-lib/info.rkt
+++ b/punct-lib/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 
 (define collection "punct")
-(define version "1.1")
+(define version "1.2")
 (define pkg-desc "implementation part of \"punct\"")
 (define license 'BlueOak-1.0.0)
 

--- a/punct-lib/private/reader-utils.rkt
+++ b/punct-lib/private/reader-utils.rkt
@@ -99,5 +99,14 @@
        [else
         (define kv (regexp-match #px"^\\s*([^:]+[\\S])\\s*:\\s*(.+[\\S])\\s*$" line))
         (cond
-          [(list? kv) (loop (cons `',(string->symbol (cadr kv)) (cons (caddr kv) kvs)))]
-          [else (balk! name in "Line does not contain : in metas block")])]))))
+          [(list? kv)
+           (define k (cadr kv))
+           (define v (caddr kv))
+           (if (char=? #\' (string-ref v 0))
+               (loop (cons `',(string->symbol k) (cons (read-meta-datum v name in) kvs)))
+               (loop (cons `',(string->symbol k) (cons v kvs))))]
+          [else (balk! name in "Line in metas block must be of form \"key: value\"")])]))))
+
+(define (read-meta-datum v name in)
+  (with-handlers ([exn:fail:read? (λ (e) (balk! name in (exn-message e)))])
+    (read (open-input-string v))))


### PR DESCRIPTION
This update would allow the use of quoted datums in meta values be prefixing the value with `'`.

So you can now store booleans and numbers in meta values, but also anything `read` would let you get away with in a single line:

```
#lang punct

---
title: This is a normal string value
fav-number: '2+3i
other-numbers: '(7 #b101 2/3)
draft?: '#t
case-insenstive-symbol-with-space: '#ci HOB| |NOB
fruit-ratings: '#hash((apple . 4) (pear . 5) (grape . 3))
name-regex: '#rx"(Bob|Alice)"
boxed: '#&17
vector: '#[23 22 98 11]
nemesis-struct: '#s(prefab-clown "Binky" "pie")
commented-number: '#| this will be equal to fourteen |# 14
non-cyclic-graph: '(#1=42 #1# #1#)
now you're just showing off: '#lang scribble/manual There are @+[3 4] words in this anonymous module
---
```

produces:

```
'#s(document
    #hasheq((boxed . #&17)
            (case-insenstive-symbol-with-space . |hob nob|)
            (commented-number . 14)
            (draft? . #t)
            (fav-number . 2+3i)
            (fruit-ratings . #hash((apple . 4) (grape . 3) (pear . 5)))
            (here-path . "39-unsaved-editor")
            (name-regex . #rx"(Bob|Alice)")
            (nemesis-struct . #s(prefab-clown "Binky" "pie"))
            (non-cyclic-graph . (42 42 42))
            (|now you're just showing off|
             .
             (module anonymous-module scribble/manual/lang
               (#%module-begin
                doc
                " There are "
                (+ 3 4)
                " words in this anonymous module")))
            (other-numbers . (7 5 2/3))
            (title . "This is a normal string value")
            (vector . #(23 22 98 11)))
    ()
    ())
```